### PR TITLE
clarify "power" key bindings logic

### DIFF
--- a/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
+++ b/data/org.mate.SettingsDaemon.plugins.media-keys.gschema.xml.in
@@ -37,6 +37,11 @@
     </key>
     <key name="power" type="s">
       <default>'&lt;Control&gt;&lt;Alt&gt;Delete'</default>
+      <summary>Shut down</summary>
+      <description>Binding to shut down.</description>
+    </key>
+    <key name="logout" type="s">
+      <default>''</default>
       <summary>Log out</summary>
       <description>Binding to log out.</description>
     </key>

--- a/plugins/media-keys/acme.h
+++ b/plugins/media-keys/acme.h
@@ -52,7 +52,8 @@ enum {
         MAGNIFIER_KEY,
         SCREENREADER_KEY,
         ON_SCREEN_KEYBOARD_KEY,
-        HANDLED_KEYS
+        LOGOUT_KEY,
+        HANDLED_KEYS,
 };
 
 static struct {
@@ -84,10 +85,11 @@ static struct {
         { REWIND_KEY, NULL, "XF86AudioRewind", NULL },
         { FORWARD_KEY, NULL, "XF86AudioForward", NULL },
         { REPEAT_KEY, NULL, "XF86AudioRepeat", NULL },
-        { RANDOM_KEY, NULL, "XF86AudioRandomPlay", NULL},
+        { RANDOM_KEY, NULL, "XF86AudioRandomPlay", NULL },
         { MAGNIFIER_KEY, "magnifier", NULL, NULL },
         { SCREENREADER_KEY, "screenreader", NULL, NULL },
         { ON_SCREEN_KEYBOARD_KEY, "on-screen-keyboard", NULL, NULL },
+        { LOGOUT_KEY, "logout", NULL, NULL },
 };
 
 #endif /* __ACME_H__ */

--- a/plugins/media-keys/msd-media-keys-manager.c
+++ b/plugins/media-keys/msd-media-keys-manager.c
@@ -499,9 +499,15 @@ do_media_action (MsdMediaKeysManager *manager)
 }
 
 static void
-do_exit_action (MsdMediaKeysManager *manager)
+do_shutdown_action (MsdMediaKeysManager *manager)
 {
         execute (manager, "mate-session-save --shutdown-dialog", FALSE, FALSE);
+}
+
+static void
+do_logout_action (MsdMediaKeysManager *manager)
+{
+        execute (manager, "mate-session-save --logout-dialog", FALSE, FALSE);
 }
 
 static void
@@ -923,8 +929,11 @@ do_action (MsdMediaKeysManager *manager,
 #endif
                 break;
         case POWER_KEY:
-                do_exit_action (manager);
+                do_shutdown_action (manager);
                 break;
+	case LOGOUT_KEY:
+		do_logout_action (manager);
+		break;
         case EJECT_KEY:
                 do_eject_action (manager);
                 break;


### PR DESCRIPTION
historically "power" key bindings calls shutdown dialog but described as logout. this is confuses users.
updated "power" key bindings description
provided additional "logout" key bindings